### PR TITLE
Fix handling of blacklist bedfile

### DIFF
--- a/SVclone/SVprocess/svp_load_data.py
+++ b/SVclone/SVprocess/svp_load_data.py
@@ -150,12 +150,12 @@ def load_blacklist(blist_file):
     descr = blist.dtype.descr
     descr[0] = (descr[0][0], '<U10')
     blist = blist.astype(descr)
-    if not len(blist) > 0 or not isinstance(blist[0][1],int) or not isinstance(blist[0][2],int):
+    if not len(blist) > 0 or not isinstance(blist[0][1], (int, np.integer)) or not isinstance(blist[0][2], (int, np.integer)):
         print('Supplied blacklist is not a valid bed file of intervals')
         return np.empty(0)
     else:
         #remove chr prefixes
-        if blist[0][0].split('chr') > 1:
+        if "chr" in blist[0][0]:
             for idx,row in enumerate(blist):
                 blist[idx][0] = blist[idx][0].split('chr')[1]
         return blist


### PR DESCRIPTION
PR addressing #44 
Changes:
* Checking the dtype of the bedfile's coords columns against both `int` and `np.integer`
* Checking whether the chromosome column contains the `chr` prefix by simple checking if it's contained in the first element of the respective column